### PR TITLE
Extended font mixin for file types

### DIFF
--- a/src/sass/site.scss
+++ b/src/sass/site.scss
@@ -13,6 +13,7 @@
 // Base Elements:
 @import 'base/_document';
 // Tools:
+@import 'tools/_functions';
 @import 'tools/_fonts';
 @import 'tools/_icons';
 @import 'tools/_transitions';

--- a/src/sass/tools/_fonts.scss
+++ b/src/sass/tools/_fonts.scss
@@ -1,9 +1,41 @@
-@mixin generate-font ($name, $url, $file, $style: normal, $weight: normal) {
+// Font generation mixin a variation of:
+// https://gist.github.com/jonathantneal/d0460e5c2d5d7f9bc5e6
+@mixin generate-font($name, $url, $file, $style: normal, $weight: normal, $exts: eot woff2 woff ttf svg) {
+  $src: null;
+
+  $extmods: (
+    eot: '?#iefix',
+    svg: '#' + str-replace($name, ' ', '_')
+  );
+
+  $formats: (
+    eot: 'embedded-opentype',
+    otf: 'opentype',
+    ttf: 'truetype'
+  );
+
+  $eot: if(index($exts, eot), url('#{$url}#{$file}.eot'), null);
+
+  @each $ext in $exts {
+    $extmod: if(
+      map-has-key($extmods, $ext),
+      $ext + map-get($extmods, $ext),
+      $ext);
+    $format: if(
+      map-has-key($formats, $ext),
+      map-get($formats, $ext),
+      $ext);
+    $src: append(
+      $src,
+      url(quote($url + $file + '.' + $extmod)) format(quote($format)),
+      comma);
+  }
+
   @font-face {
-    font-family: $name;
+    font-family: quote($name);
     font-weight: $weight;
     font-style: $style;
-    src: url('#{$url}#{$file}.eot');
-    src: url('#{$url}#{$file}.eot?#iefix') format('embedded-opentype'), url('#{$url}#{$file}.woff') format('woff'), url('#{$url}#{$file}.ttf')  format('truetype'), url('#{$url}#{$file}.svg#svgFontName') format('svg');
+    src: $eot;
+    src: $src;
   }
 }

--- a/src/sass/tools/_functions.scss
+++ b/src/sass/tools/_functions.scss
@@ -1,0 +1,9 @@
+@function str-replace($string, $search, $replace: '') {
+  $index: str-index($string, $search);
+
+  @if $index {
+    @return str-slice($string, 1, $index - 1) + $replace + str-replace(str-slice($string, $index + str-length($search)), $search, $replace);
+  }
+
+  @return $string;
+}


### PR DESCRIPTION
Extended the mixin using [Jonathan Neal's](https://gist.github.com/jonathantneal/d0460e5c2d5d7f9bc5e6). Tweaked his to include lone `eot` statement and alternate `eot` file designation.

We may later want to move the functions partial before variables to potentially use some there (e.g., converting units).