### PR TITLE
change column size class names to modify base column class

### DIFF
--- a/src/sass/tools/_layout.scss
+++ b/src/sass/tools/_layout.scss
@@ -17,7 +17,7 @@
 
 @mixin generate-columns ($number) {
   @for $i from 1 through $number {
-    .o-column-#{$i} {
+    .o-column--#{$i} {
       width: (100% * $i / $number);
     }
     .o-column--offset-#{$i} {


### PR DESCRIPTION
`.o-column-5` --> `.o-column--5`

Classes that determine a column's width should be treated as modifiers of a base column class for consistency among other generated size classes. This also allows for a future `.o-column` base class which might be applied to all columns and not interfere with their size.