### PR TITLE
Removing some public directories from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,3 @@ node_modules
 .DS_Store
 npm-debug.log
 dist
-public
-public/css/
-public/imgs/


### PR DESCRIPTION
These ignores, also cause project level public stuff to be ignored, which we don't want.