### PR TITLE
Add ESlint test for all project level code

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 src/js/vendor/**/*.js
+/dist/site.js

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "gulpfile.babel.js",
   "scripts": {
     "start": "concurrently --kill-others \"gulp\"",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./node_modules/.bin/eslint eslint ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
You should not have ESlint installed globally. You can remove via `npm uninstall -g eslint`.

`eslint .` will run recursively and lint all .js files project level in Travis now.